### PR TITLE
Add the option `foo & bar` for `autocomplete_input_values`

### DIFF
--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -129,7 +129,7 @@ class DeformDemo(object):
 
         reqts = form.get_widget_resources()
 
-        printer = pprint.PrettyPrinter(width=1)
+        printer = pprint.PrettyPrinter()
         printer.format = my_safe_repr
         output = printer.pformat(captured)
         captured = highlight(output, PythonLexer(), formatter)
@@ -339,7 +339,7 @@ class DeformDemo(object):
     def autocomplete_input_values(self):
         text = self.request.params.get("term", "")
         return [
-            x for x in ["bar", "baz", "two", "three"] if x.startswith(text)
+            x for x in ["bar", "baz", "two", "three", "foo & bar"] if x.startswith(text)
         ]
 
     @view_config(renderer="templates/form.pt", name="textarea")

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -339,7 +339,9 @@ class DeformDemo(object):
     def autocomplete_input_values(self):
         text = self.request.params.get("term", "")
         return [
-            x for x in ["bar", "baz", "two", "three", "foo & bar"] if x.startswith(text)
+            x
+            for x in ["bar", "baz", "two", "three", "foo & bar"]
+            if x.startswith(text)
         ]
 
     @view_config(renderer="templates/form.pt", name="textarea")

--- a/deformdemo/__init__.py
+++ b/deformdemo/__init__.py
@@ -291,7 +291,7 @@ class DeformDemo(object):
     @view_config(renderer="templates/form.pt", name="autocomplete_input")
     @demonstrate("Autocomplete Input Widget")
     def autocomplete_input(self):
-        choices = ['bar', 'baz', 'two', 'three', 'foo & bar']
+        choices = ["bar", "baz", "two", "three", "foo & bar", "one < two"]
         widget = deform.widget.AutocompleteInputWidget(
             values=choices, min_length=1
         )
@@ -340,7 +340,7 @@ class DeformDemo(object):
         text = self.request.params.get("term", "")
         return [
             x
-            for x in ["bar", "baz", "two", "three", "foo & bar"]
+            for x in ["bar", "baz", "two", "three", "foo & bar", "one < two"]
             if x.startswith(text)
         ]
 

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -100,6 +100,10 @@ def action_chains_xpath_on_select(option_xpath):
     )
 
 
+def action_chains_on_css_selector(css_selector):
+    return ActionChains(browser).move_to_element(findcss(css_selector))
+
+
 @give_selenium_some_time
 def findid(elid, clickable=True):
     """Find Selenium element by CSS id.
@@ -2737,9 +2741,9 @@ class AutocompleteInputWidgetTests(Base, unittest.TestCase):
         self.assertTrue("bar" in text)
 
     def test_special_chars(self):
-        findid('deformField1').send_keys('foo')
+        findid("deformField1").send_keys("foo")
         self.assertTrue(findxpath('//p[text()="foo & bar"]').is_displayed())
-        findcss(".tt-suggestion").click()
+        action_chains_on_css_selector(".tt-suggestion").click().perform()
         findid("deformsubmit").click()
         self.assertRaises(NoSuchElementException, findcss, ".has-error")
         text = findid("captured").text

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -2741,7 +2741,7 @@ class AutocompleteInputWidgetTests(Base, unittest.TestCase):
         # py2/py3 compat, py2 adds extra u prefix
         self.assertTrue("bar" in text)
 
-    def test_special_chars(self):
+    def test_ampersand(self):
         findid("deformField1").send_keys("foo")
         self.assertTrue(findxpath('//p[text()="foo & bar"]').is_displayed())
         action_chains_on_css_selector(".tt-suggestion").click().perform()
@@ -2750,6 +2750,17 @@ class AutocompleteInputWidgetTests(Base, unittest.TestCase):
         text = findid("captured").text
         # py2/py3 compat, py2 adds extra u prefix
         self.assertTrue("foo & bar" in text)
+
+    def test_less_than(self):
+        findid("deformField1").send_keys("one")
+        self.assertTrue(findxpath('//p[text()="one < two"]').is_displayed())
+        findid("deformField1").send_keys(Keys.ARROW_DOWN)
+        findid("deformField1").send_keys(Keys.ENTER)
+        findid("deformsubmit").click()
+        self.assertRaises(NoSuchElementException, findcss, ".has-error")
+        text = findid("captured").text
+        # py2/py3 compat, py2 adds extra u prefix
+        self.assertTrue("one < two" in text)
 
 
 class AutocompleteRemoteInputWidgetTests(Base, unittest.TestCase):
@@ -2784,7 +2795,6 @@ class AutocompleteRemoteInputWidgetTests(Base, unittest.TestCase):
         self.assertTrue(findxpath('//p[text()="two"]').is_displayed())
         self.assertTrue(findxpath('//p[text()="three"]').is_displayed())
 
-        # action_chains_on_xpath('//p[text()="two"]').click().perform()
         findid("deformField1").send_keys(Keys.ARROW_DOWN)
         findid("deformField1").send_keys(Keys.ENTER)
         findid("deformsubmit").click()

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -2784,8 +2784,9 @@ class AutocompleteRemoteInputWidgetTests(Base, unittest.TestCase):
         self.assertTrue(findxpath('//p[text()="two"]').is_displayed())
         self.assertTrue(findxpath('//p[text()="three"]').is_displayed())
 
-        action_chains_on_xpath('//p[text()="two"]').click().perform()
-
+        # action_chains_on_xpath('//p[text()="two"]').click().perform()
+        findid("deformField1").send_keys(Keys.ARROW_DOWN)
+        findid("deformField1").send_keys(Keys.ENTER)
         findid("deformsubmit").click()
         self.assertRaises(NoSuchElementException, findcss, ".has-error")
 

--- a/deformdemo/test.py
+++ b/deformdemo/test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+import ast
 import datetime
 from decimal import Decimal
 import logging
@@ -354,9 +355,9 @@ class CheckboxChoiceWidgetTests(Base, unittest.TestCase):
         self.assertTrue(findid("deformField1-1").is_selected())
         self.assertTrue(findid("deformField1-2").is_selected())
         captured = findid("captured").text
-        self.assertSimilarRepr(
-            captured, "{'pepper': {'chipotle', 'habanero', 'jalapeno'}}"
-        )
+        expected = {'pepper': {'jalapeno', 'habanero', 'chipotle'}}
+        captured = ast.literal_eval(captured)
+        self.assertEqual(expected, captured)
 
 
 class CheckboxChoiceWidgetInlineTests(Base, unittest.TestCase):
@@ -400,9 +401,9 @@ class CheckboxChoiceWidgetInlineTests(Base, unittest.TestCase):
         self.assertTrue(findid("deformField1-1").is_selected())
         self.assertTrue(findid("deformField1-2").is_selected())
         captured = findid("captured").text
-        self.assertSimilarRepr(
-            captured, "{'pepper': {'chipotle', 'habanero', 'jalapeno'}}"
-        )
+        expected = {'pepper': {'jalapeno', 'habanero', 'chipotle'}}
+        captured = ast.literal_eval(captured)
+        self.assertEqual(expected, captured)
 
 
 class CheckboxChoiceReadonlyTests(Base, unittest.TestCase):
@@ -2590,9 +2591,9 @@ class Select2WidgetTagsMultipleTests(Base, unittest.TestCase):
         # after form submission typed value appear in captured
         findid("deformsubmit").click()
         captured = findid("captured").text
-        self.assertSimilarRepr(
-            captured, "{'pepper': {'hello', 'qwerty'} }",
-        )
+        captured = ast.literal_eval(captured)
+        expected = {'pepper': {'hello', 'qwerty'}}
+        self.assertEqual(expected, captured)
 
 
 class SelectWithDefaultTests(Base, unittest.TestCase):


### PR DESCRIPTION
- Change the method to click an autocomplete item
- Remove argument `width=1` from `pprint.PrettyPrinter()` because it breaks the output on spaces into a new line for each